### PR TITLE
chore(github-actions): Automatically lint PR titles

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,21 @@
+# This workflow ensures PR titles match the Conventional Commits spec.
+# see https://www.conventionalcommits.org/en/v1.0.0/
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        # Action constomization is available here :
+        # https://github.com/marketplace/actions/semantic-pull-request#configuration
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduces a github-actions workflow that lints PR titles.

It leverages the public [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request) action from the marketplace.